### PR TITLE
Ignore open handles after tests finish

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -22,7 +22,7 @@
     "script:drop-index": "PG_SB_DROP_COL_AND_INDEX=true ts-node-esm scripts/create-index.ts",
     "script:create-movies": "PG_SB_CREATE_MOVIES=true ts-node-esm ./scripts/create-movies.ts",
     "script:drop-movies": "PG_SB_DROP_MOVIES=true ts-node-esm ./scripts/create-movies.ts",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest --runInBand",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --runInBand --forceExit",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --runInBand --watchAll"
   },
   "repository": {


### PR DESCRIPTION
Without this, `yarn test` hangs indefinitely.  This is because our client keeps the database connection open indefinitely, lacking a suitable interface to indicate it's safe to close it.  We consider this OK because the web server using this connection will likely never willingly terminate.  Also, adding complexity that Algolia's client doesn't have may hamper adoption.